### PR TITLE
update discord invite links resolves #44

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ All PRs will get a Netlify preview and URL so that it can be shared and tested b
 
 Need help with your contribution?
 
-- **Discord**: Join our [community Discord](https://discord.gg/kfJkJ3Xd) for real-time support
+- **Discord**: Join our [community Discord](https://discord.gg/G7CSTKZcuT) for real-time support
 - **GitHub Issues**: Create an issue for technical problems
 - **Mailing List**: Subscribe to [community@dev-rel.org](https://lists.dev-rel.org/g/community) for announcements
 - **Working Groups**: Attend [working group meetings](https://github.com/DevRel-Foundation/site/blob/main/src/routes/about/working-groups/+page.svelte) for collaborative discussions
@@ -274,7 +274,7 @@ Need help with your contribution?
 If you have questions about contributing or need clarification on any guidelines:
 
 1. Search existing [GitHub Issues](https://github.com/DevRel-Foundation/site/issues)
-2. Ask in our [Discord community](https://discord.gg/kfJkJ3Xd)
+2. Ask in our [Discord community](https://discord.gg/G7CSTKZcuT)
 3. Contact us at [info@dev-rel.org](mailto:info@dev-rel.org)
 
 ---

--- a/src/lib/components/nav/Footer.svelte
+++ b/src/lib/components/nav/Footer.svelte
@@ -27,7 +27,7 @@
     <div class="footer-column">
       <h2>Find Us</h2>
       <div class="social-icons">
-        <a href="https://discord.gg/kfJkJ3Xd" target="_blank" rel="noopener noreferrer" aria-label="Join our Discord">
+        <a href="https://discord.gg/G7CSTKZcuT" target="_blank" rel="noopener noreferrer" aria-label="Join our Discord">
           <img src={DiscordIcon} alt="Discord" />
         </a>
         <a href="https://linkedin.com/company/devrel-foundation" target="_blank" rel="noopener noreferrer" aria-label="Follow us on LinkedIn">

--- a/src/lib/components/nav/Nav.svelte
+++ b/src/lib/components/nav/Nav.svelte
@@ -222,7 +222,7 @@
                 <h3 class="menu-header">Community Resources</h3>
                 <div class="dropdown-items">
 
-                  <a href="https://discord.gg/kfJkJ3Xd" onclick={closeAll} target="_blank" rel="noopener noreferrer">
+                  <a href="https://discord.gg/G7CSTKZcuT" onclick={closeAll} target="_blank" rel="noopener noreferrer">
                     <div class="dropdown-item-brief">
                       <span class="item-title">
                         <img src={DiscordIcon} alt="Join us on Discord" class="social-icon" />
@@ -268,7 +268,7 @@
               <div class="dropdown-section">
                 <h3 class="menu-header">Community Resources</h3>
                 <div class="dropdown-items">
-                  <a href="https://discord.gg/kfJkJ3Xd" onclick={closeAll} target="_blank" rel="noopener noreferrer">
+                  <a href="https://discord.gg/G7CSTKZcuT" onclick={closeAll} target="_blank" rel="noopener noreferrer">
                     <div class="dropdown-item-brief">
                       <span class="item-title">
                         <img src={DiscordIcon} alt="Join us on Discord" class="social-icon" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -123,7 +123,7 @@
       "foundingDate": "2024",
       "sameAs": [
         "https://github.com/devrel-foundation",
-        "https://discord.gg/kfJkJ3Xd"
+        "https://discord.gg/G7CSTKZcuT"
       ],
       "contactPoint": {
         "@type": "ContactPoint",
@@ -173,7 +173,7 @@
 			<img src={NetworkIcon} alt="Network" />
 			<h3 class="content-box-heading">Join Us</h3>
 			<p>
-				Partner with us on <a href="https://discord.gg/kfJkJ3Xd">Discord</a> and <a href="https://github.com/DevRel-Foundation">GitHub</a> to share your voice and collaborate with peers.
+				Partner with us on <a href="https://discord.gg/G7CSTKZcuT">Discord</a> and <a href="https://github.com/DevRel-Foundation">GitHub</a> to share your voice and collaborate with peers.
 			</p>
 			<button class="content-button" on:click={handleJoinClick}>Get Involved</button>
 		</div>

--- a/src/routes/about/working-groups/+page.svelte
+++ b/src/routes/about/working-groups/+page.svelte
@@ -108,7 +108,7 @@
 		</p>
 
 		<p>
-		<a href="https://discord.gg/kfJkJ3Xd">
+		<a href="https://discord.gg/G7CSTKZcuT">
 			<img src={DiscordIcon} alt="Lets Chat" class="social-icon" /> #resource-aggregation
 		</a>
 		</p>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -71,7 +71,7 @@
         },
         "sameAs": [
           "https://github.com/devrel-foundation",
-          "https://discord.gg/kfJkJ3Xd"
+          "https://discord.gg/G7CSTKZcuT"
         ],
         "contactPoint": {
           "@type": "ContactPoint",

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -12,7 +12,7 @@
   const gettingHelp = [
     { label: "LFX Project Control Center Support (Meetings)", url: "https://lfx.linuxfoundation.org/services/request" },
     { label: "Report a Website Issue", url: "https://github.com/DevRel-Foundation/site/issues" },
-    { label: "Give Feedback on Discord (Chat)", url: "https://discord.gg/kfJkJ3Xd" },
+    { label: "Give Feedback on Discord (Chat)", url: "https://discord.gg/G7CSTKZcuT" },
     { label: "Give Feedback on GitHub Discussions (Forum)", url: "https://github.com/DevRel-Foundation/governance/discussions" },
   ];
 </script>

--- a/src/routes/join-us/+page.svelte
+++ b/src/routes/join-us/+page.svelte
@@ -125,9 +125,9 @@
 		</p>
 
 		<div class="steps">
-			<a href="https://discord.gg/kfJkJ3Xd" class="cta-button" target="_blank">Step 1. Join the Discord Community</a>
+			<a href="https://discord.gg/G7CSTKZcuT" class="cta-button" target="_blank">Step 1. Join the Discord Community</a>
 			<p>
-				The foundation's <a href="https://discord.gg/kfJkJ3Xd">Discord server</a> is the primary synchronous communication channel for community participants. Here, you can connect with other DevRel professionals, ask questions, share experiences, and stay updated on activities.
+				The foundation's <a href="https://discord.gg/G7CSTKZcuT">Discord server</a> is the primary synchronous communication channel for community participants. Here, you can connect with other DevRel professionals, ask questions, share experiences, and stay updated on activities.
 			</p>
 
 			<a href="https://lists.dev-rel.org/g/community/join" class="cta-button" target="_blank">Step 2. Sign-up for the Mailing List</a>


### PR DESCRIPTION
Used a temporary link to a specific channel so swapped it out with an invite link to the announcements channel that has no limit of members and no expiration.