### PR TITLE
fix issue 46 add mediaquery

### DIFF
--- a/src/lib/components/nav/Nav.svelte
+++ b/src/lib/components/nav/Nav.svelte
@@ -726,20 +726,22 @@
       gap: 0;
     }
     
-    .dropdown-section:not(:first-child) {
-      display: none;
-    }
-
-    .item-description {
-      display: none;
-    }
-
-    .dropdown-item {
-      padding: var(--space-2xs);
-    }
-
-    .menu-header {
-      display: none;
-    }
+  @media (max-width: 768px) {
+  .dropdown-section:not(:first-child) {
+    display: block;
   }
+
+  .item-description {
+    display: block;
+  }
+
+  .menu-header {
+    display: block;
+  }
+}
+
+
+
+  }
+
 </style>


### PR DESCRIPTION
- Fixed an issue  #46 where dropdown sections, item descriptions, and menu headers were hidden on mobile screens.
- Added a media query for screens smaller than 768px to display all dropdown elements.
- Ensures full dropdown functionality and improves mobile responsiveness.
![Uploading Screenshot 2025-08-16 152724.png…]()
