### PR TITLE
add definitions page for tools catalog facets

### DIFF
--- a/src/lib/components/ui/atoms/DropdownMenu.svelte
+++ b/src/lib/components/ui/atoms/DropdownMenu.svelte
@@ -76,7 +76,6 @@
   border: 1px solid var(--color-logo-text, #145C36);
   border-radius: var(--radius-m);
   padding: var(--space-xs) var(--space-m);
-  font-size: var(--step-0);
   cursor: pointer;
   text-align: left;
   display: flex;
@@ -130,7 +129,6 @@
 .dropdown-item {
   padding: var(--space-xs) var(--space-m);
   cursor: pointer;
-  font-size: var(--step-0);
   color: var(--color-text);
   background: none;
   border-bottom: 0.5px solid var(--color-logo-text);

--- a/src/lib/components/ui/molecules/projects/tools-catalog/ToolFacetDropdown.svelte
+++ b/src/lib/components/ui/molecules/projects/tools-catalog/ToolFacetDropdown.svelte
@@ -14,7 +14,7 @@
   <label class="facet-label">
     {label}
     {#if help}
-      <InfoTooltip label="" href="" alt={help} />
+      <InfoTooltip label="" href="/projects/tools-catalog/definitions" alt={help} />
     {/if}
   </label>
   <DropdownMenu
@@ -32,11 +32,12 @@
   flex-direction: column;
   gap: var(--space-xs);
   margin-bottom: var(--space-m);
+  font-size: var(--step--1);
   scrollbar-width: thin;        /* Firefox: thin scrollbar */
-
 }
+
 .facet-label {
-  font-size: var(--step-0);
+  font-size: var(--step--1);
   font-weight: 600;
   color: var(--color-text);
   margin-bottom: 0.1em;

--- a/src/lib/components/ui/organisms/projects/ToolsFilter.svelte
+++ b/src/lib/components/ui/organisms/projects/ToolsFilter.svelte
@@ -76,11 +76,12 @@
 .search-filter {
   display: flex;
   flex-direction: column;
+  font-size: var(--step--1);
   gap: var(--space-xs);
 }
 
 .search-label {
-  font-size: var(--step-0);
+  font-size: var(--step--1);
   font-weight: 600;
   color: var(--color-text);
   margin-bottom: 0.1em;

--- a/src/lib/server/projects/tools-catalog/schema-reader.ts
+++ b/src/lib/server/projects/tools-catalog/schema-reader.ts
@@ -38,7 +38,8 @@ export async function getJobCategories() {
     .map(key => ({
       value: defs[key].const,
       description: defs[key].description
-    }));
+    }))
+    .sort((a, b) => a.value.localeCompare(b.value));
   return categories;
 }
 
@@ -50,7 +51,8 @@ export async function getJobOutcomes() {
     .map(key => ({
       value: defs[key].const,
       description: defs[key].description
-    }));
+    }))
+    .sort((a, b) => a.value.localeCompare(b.value));
   return outcomes;
 }
 
@@ -62,7 +64,8 @@ export async function getJobMotivations() {
     .map(key => ({
       value: defs[key].const,
       description: defs[key].description
-    }));
+    }))
+    .sort((a, b) => a.value.localeCompare(b.value));
   return motivations;
 }
 
@@ -74,6 +77,7 @@ export async function getJobSituations() {
     .map(key => ({
       value: defs[key].const,
       description: defs[key].description
-    }));
+    }))
+    .sort((a, b) => a.value.localeCompare(b.value));
   return situations;
 }

--- a/src/routes/projects/tools-catalog/definitions/+page.server.ts
+++ b/src/routes/projects/tools-catalog/definitions/+page.server.ts
@@ -1,0 +1,12 @@
+import { getJobCategories, getJobOutcomes } from '$lib/server/projects/tools-catalog/schema-reader';
+
+export async function load() {
+	const [categories, outcomes] = await Promise.all([
+		getJobCategories(),
+		getJobOutcomes()
+	]);
+	return {
+		categories,
+		outcomes
+	};
+}

--- a/src/routes/projects/tools-catalog/definitions/+page.svelte
+++ b/src/routes/projects/tools-catalog/definitions/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import InfoPage from '$lib/components/ui/organisms/InfoPage.svelte';
+
+	export let data;
+</script>
+
+
+<InfoPage title="Tools Catalog Definitions" 
+  description="Definitions for job categories and outcomes used in the DevRel Foundation Tools Catalog."
+  breadcrumbs={[{label:"About | Tools Catalog", link: "/projects/tools-catalog"}]}
+  wide={true}
+  >
+
+    <h2>Job Categories</h2>
+    <table class="styled-table">
+        <thead>
+            <tr>
+                <th>Category</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {#each data.categories as cat}
+                <tr>
+                    <td><b>{cat.value}</b></td>
+                    <td>{cat.description}</td>
+                </tr>
+            {/each}
+        </tbody>
+    </table>
+
+    <h2>Job Outcomes</h2>
+    <table class="styled-table">
+        <thead>
+            <tr>
+                <th>Outcome</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {#each data.outcomes as outcome}
+                <tr>
+                    <td><b>{outcome.value}</b></td>
+                    <td>{outcome.description}</td>
+                </tr>
+            {/each}
+        </tbody>
+    </table>
+
+</InfoPage>
+
+
+
+<style>
+.styled-table {
+    border-collapse: collapse;
+    margin: 25px 0;
+    font-size: 0.9em;
+    font-family: sans-serif;
+    min-width: 400px;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+}
+
+.styled-table thead tr {
+    background-color: var(--color-button-background);
+    color: var(--color-text-dark);
+    text-align: left;
+}
+
+.styled-table th,
+.styled-table td {
+    padding: 12px 15px;
+}
+
+
+
+.styled-table tbody tr {
+    border-bottom: 1px solid #dddddd;
+}
+
+.styled-table tbody tr:nth-of-type(even) {
+    background-color: var(--color-background-secondary-1);
+}
+
+.styled-table tbody tr:last-of-type {
+    border-bottom: 2px solid #009879;
+}
+
+.styled-table td:first-child,
+.styled-table th:first-child {
+    min-width: 180px; /* or use width: 180px for fixed */
+    white-space: nowrap;
+}
+
+</style>


### PR DESCRIPTION
Adding a page for the info bubbles that lists all of the categories and outcomes so that its easier to understand the various facets in the tools catalog.