### PR TITLE
 added google tag; refactored component for cookies

### DIFF
--- a/src/lib/ui/CookieConsent.svelte
+++ b/src/lib/ui/CookieConsent.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  // Use callback props instead of createEventDispatcher
+  export let onAccept: () => void = () => {};
+  export let onReject: () => void = () => {};
+</script>
+
+<div id="cookie-consent-banner" class="cookie-banner" role="region" aria-label="Cookie consent">
+  <div class="cookie-inner">
+    <div class="cookie-message">
+      <p>
+        We use cookies and analytics to improve the user experience and set priorities based on usage. Your privacy is important to us.
+        <a href="/privacy">Learn more</a>
+      </p>
+    </div>
+    <div class="cookie-actions">
+      <button on:click={onAccept} class="btn-accept">Accept All</button>
+      <button on:click={onReject} class="btn-reject">Reject</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0,36,46,0.95);
+    color: white;
+    padding: 1rem;
+    z-index: 10000;
+    border-top: 2px solid var(--color-mint-dark, #79bf44);
+    backdrop-filter: blur(10px);
+  }
+
+  .cookie-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .cookie-message {
+    flex: 1;
+    min-width: 300px;
+  }
+
+  .cookie-message p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+  }
+
+  .cookie-message a {
+    color: var(--color-mint, #79bf44);
+    text-decoration: underline;
+  }
+
+  .cookie-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .btn-accept {
+    background: var(--color-mint-dark, #79bf44);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .btn-reject {
+    background: transparent;
+    color: white;
+    border: 1px solid rgba(255,255,255,0.3);
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   import { browser } from '$app/environment';
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
-  import { PUBLIC_GA_ID } from '$env/static/public';
+  import * as env from '$env/dynamic/public';
 
   import '../reset.css';
   import '../app.css';
@@ -45,7 +45,7 @@
       posthog.capture('$pageview');
       posthog.capture('cookie_consent_given', { action: 'accept' });
     }
-    const gaId = (typeof PUBLIC_GA_ID !== 'undefined' && PUBLIC_GA_ID) ? PUBLIC_GA_ID : 'G-Z5ZG34WJP1';
+  const gaId = (typeof env.PUBLIC_GA_ID !== 'undefined' && env.PUBLIC_GA_ID) ? env.PUBLIC_GA_ID : 'G-Z5ZG34WJP1';
     injectGA(gaId);
     showConsent.set(false);
   }
@@ -104,8 +104,8 @@
       if (hasConsent === 'true') {
         posthog.opt_in_capturing();
         posthog.capture('$pageview');
-        // initialize GA immediately as consent already given
-        const gaId = (typeof PUBLIC_GA_ID !== 'undefined' && PUBLIC_GA_ID) ? PUBLIC_GA_ID : 'G-Z5ZG34WJP1';
+  // initialize GA immediately as consent already given
+  const gaId = (typeof env.PUBLIC_GA_ID !== 'undefined' && env.PUBLIC_GA_ID) ? env.PUBLIC_GA_ID : 'G-Z5ZG34WJP1';
         injectGA(gaId);
       } else if (hasConsent === null) {
         // Show consent banner for new users


### PR DESCRIPTION
A few small updates
- added google tag manager in addition to posthog
- refactored component for the cookie consent banner

Intent behind this is to create some tutorials explaining how to set things like this up, what metrics can be insightful for community engagement, etc. by collecting data that we can share as an example.