### PR TITLE
Voice and tone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ We're excited to have you contribute to our mission.
 - [Code of Conduct](#code-of-conduct)
 - [Ways to Contribute](#ways-to-contribute)
 - [Blog Contribution Guidelines](#blog-contribution-guidelines)
+- [Site-Wide Content Standards](#site-wide-content-standards)
 - [Development Setup](#development-setup)
 - [Support](#support)
 
@@ -54,6 +55,8 @@ Help develop new features, fix bugs, or improve the site's technical implementat
 
 You may be interested in contributing to our community blog but any contributions must be in alignment with our mission and the open-source spirit of the foundation we belong.
 
+For writing style, tone, naming conventions (Developer Relations Foundation / DevRel Foundation / DRF), and heading structure, see the [Voice and tone guide](/brand#voice-and-tone).
+
 Here's what you need to know:
 
 ### Content We Welcome
@@ -86,7 +89,7 @@ title: "Your Blog Post Title"
 excerpt: "A brief description (1-2 sentences) that will appear in listings"
 author: "@your-github-username"
 date: "YYYY-MM-DD"
-category: "exec|early-ic|pro-lead|exec"
+category: "announce|early-ic|pro-lead|exec"
 tags: ["tag1", "tag2", "tag3"]
 ---
 ```
@@ -96,17 +99,18 @@ tags: ["tag1", "tag2", "tag3"]
 - `excerpt`: Brief summary for social sharing and listings
 - `author`: Your GitHub username (prefixed with @)
 - `date`: Publication date in YYYY-MM-DD format
-- `category`: Primary audience (exec, dev, marketing, community, product)
+- `category`: Content type or primary audience — one of:
+  - `announce` — announcements from the DevRel Foundation
+  - `early-ic` — resources and insights for early-career DevRel professionals
+  - `pro-lead` — advanced strategies and leadership perspectives for experienced practitioners
+  - `exec` — executive-level insights on the business value of DevRel
 - `tags`: 2-5 relevant tags for categorization
 
 ### Content Guidelines
 
 #### Writing Style
-- Write in a clear, accessible manner
-- Use active voice where possible
-- Include practical examples and actionable insights
-- Structure content with clear headings and subheadings
-- Keep paragraphs concise and scannable
+
+Follow the [Voice and Tone guide](/brand#voice-and-tone) for tone, sentence structure, naming conventions, heading levels, and general writing standards.
 
 #### Attribution and Sources
 - Properly cite all sources and references
@@ -118,8 +122,9 @@ tags: ["tag1", "tag2", "tag3"]
 - Use high-quality, relevant images
 - Ensure you have rights to use any images included
 - Optimize images for web (recommended: under 500KB)
-- Include descriptive alt text for accessibility
 - Store images in `/static/images/blog/` directory
+
+Alt text and accessibility requirements are covered under [Site-Wide Content Standards](#site-wide-content-standards).
 
 ## Blog Submission Process
 
@@ -181,15 +186,14 @@ If changes are requested:
 - **Expedited Review**: Available for time-sensitive content (contact site maintainers)
 - **Publication Date**: Posts are typically published immediately upon approval
 
-## Content Guidelines
+## Site-Wide Content Standards
 
 ### Inclusivity and Accessibility
 
-- Use inclusive language that welcomes all community members
-- Avoid jargon without proper explanation
-- Include alt text for images
-- Use proper heading structure for screen readers
-- Consider diverse perspectives and experiences
+Language and tone — including inclusive language and jargon — are covered in the [Voice and Tone guide](/brand#voice-and-tone). For the site specifically:
+
+- Include descriptive alt text for all images.
+- Use proper heading levels (H1 → H2 → H3) so screen readers can navigate.
 
 ### Technical Standards
 
@@ -200,10 +204,7 @@ If changes are requested:
 
 ### Community Standards
 
-- Respect different viewpoints and approaches
-- Encourage constructive discussion
-- Avoid inflammatory or divisive language
-- Focus on practical solutions and shared learning
+Conduct is covered by the [Code of Conduct](https://github.com/DevRel-Foundation/governance/blob/main/code_of_conduct.md); language and tone by the [Voice and Tone guide](/brand#voice-and-tone). Focus contributions on practical solutions and shared learning.
 
 ### Examples
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="mdsvex/globals" />
+
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {
@@ -11,11 +13,21 @@ declare global {
 }
 
 declare module '*.md' {
-	import type { SvelteComponent } from 'svelte'
+	import type { Component } from 'svelte';
 
-	export default class Comp extends SvelteComponent{}
+	const component: Component;
+	export default component;
 
-	export const metadata: Record<string, unknown>
+	export const metadata: Record<string, unknown>;
+}
+
+declare module '*.svx' {
+	import type { Component } from 'svelte';
+
+	const component: Component;
+	export default component;
+
+	export const metadata: Record<string, unknown>;
 }
 
 export {};

--- a/src/lib/components/nav/Footer.svelte
+++ b/src/lib/components/nav/Footer.svelte
@@ -25,6 +25,13 @@
     </div>
 
     <div class="footer-column">
+      <h2>Legal</h2>
+      <a href="/privacy">Privacy Policy</a>
+      <a href="/terms">Terms of Use</a>
+      <a href="https://github.com/DevRel-Foundation/governance/blob/main/code_of_conduct.md" target="_blank" rel="noopener noreferrer">Code of Conduct ↗</a>
+    </div>
+
+    <div class="footer-column">
       <h2>Find Us</h2>
       <div class="social-icons">
         <a href="https://discord.gg/G7CSTKZcuT" target="_blank" rel="noopener noreferrer" aria-label="Join our Discord">
@@ -58,12 +65,7 @@
       
       <br />
 
-      For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank" rel="noopener noreferrer">Trademark Usage</a>  page. Linux is a registered trademark of Linus Torvalds. 
-
-      <br />
-
-      <a href="/privacy">Privacy Policy</a> • 
-      <a href="https://github.com/DevRel-Foundation/governance/blob/main/code_of_conduct.md" target="_blank" rel="noopener noreferrer">Code of Conduct</a> • <a href="/terms">Terms of Use</a>
+      For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank" rel="noopener noreferrer">Trademark Usage</a>  page. Linux is a registered trademark of Linus Torvalds.
     </p>
   </div>
 </footer> 
@@ -121,8 +123,15 @@
   
   @media (min-width: 769px) {
     .footer-content {
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr;
       gap: var(--space-l);
+      justify-items: start;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .footer-content {
+      grid-template-columns: 1fr 1fr 1fr 1fr;
       justify-items: center;
     }
   }

--- a/src/routes/brand/+page.svelte
+++ b/src/routes/brand/+page.svelte
@@ -14,7 +14,6 @@
     <li><a href="#colors">Colors</a></li>
     <li><a href="#usage">Color Usage</a></li>
     <li><a href="#usage">Typography</a></li>
-    <li><a href="/terms">Terms of Use</a></li>
   </ul>
 </nav>
 

--- a/src/routes/brand/+page.svelte
+++ b/src/routes/brand/+page.svelte
@@ -1,4 +1,6 @@
-
+<script>
+  import VoiceAndTone from './voice-and-tone.md';
+</script>
 
 <div class="container container-content">
 
@@ -13,12 +15,13 @@
     <li><a href="#logos">Logos</a></li>
     <li><a href="#colors">Colors</a></li>
     <li><a href="#usage">Color Usage</a></li>
-    <li><a href="#usage">Typography</a></li>
+    <li><a href="#typography">Typography</a></li>
+    <li><a href="#voice-and-tone">Voice and tone</a></li>
   </ul>
 </nav>
 
 
-<h2 id="usage">Logos</h2>
+<h2 id="logos">Logos</h2>
 <p>
     Download <a href="https://github.com/DevRel-Foundation/drf-branding" target="_blank" rel="noopener noreferrer">Brand Assets ↗</a> from the GitHub repository.
 </p>
@@ -215,8 +218,12 @@
   </tbody>
 </table>
 
-<h2 id="usage">Typography</h2>
+<h2 id="typography">Typography</h2>
 
+<section id="voice-and-tone" class="brand-markdown">
+  <h2>Voice and Tone</h2>
+  <VoiceAndTone />
+</section>
 
 </div>
 
@@ -280,6 +287,45 @@
 
 .toc a:hover {
   color: var(--color-link);
+}
+
+.brand-markdown {
+  margin-top: 2rem;
+}
+
+.brand-markdown :global(h2) {
+  font-size: var(--step-2);
+  color: var(--color-text);
+  margin: var(--space-xl) 0 var(--space-m);
+  border-bottom: 2px solid var(--color-background-secondary-2);
+  padding-bottom: var(--space-xs);
+}
+
+.brand-markdown :global(h2:first-child) {
+  margin-top: 0;
+}
+
+.brand-markdown :global(h3) {
+  font-size: var(--step-1);
+  color: var(--color-text);
+  margin: var(--space-l) 0 var(--space-s);
+}
+
+.brand-markdown :global(p) {
+  line-height: 1.6;
+  margin-bottom: var(--space-m);
+  color: var(--color-text);
+}
+
+.brand-markdown :global(ul) {
+  margin-bottom: var(--space-m);
+  padding-left: var(--space-l);
+}
+
+.brand-markdown :global(li) {
+  margin-bottom: var(--space-xs);
+  line-height: 1.6;
+  color: var(--color-text);
 }
 
 </style>

--- a/src/routes/brand/voice-and-tone.md
+++ b/src/routes/brand/voice-and-tone.md
@@ -1,0 +1,71 @@
+## Overview
+
+There are two points of perspective from which we write:
+
+- That which represents the DRF as an organization
+- That which represents an individual — think authenticity
+
+In both cases, we write in a natural, friendly, and respectful voice. We write for a global audience. We represent the DRF and LF; we should be mindful of this in our conduct and content.
+
+A formal register isn't conducive to friendliness, so we generally avoid this unless necessary. Contractions and natural phrasing are fine. We don't write exactly as we speak; most people's speech tends to be verbose and colloquial.
+
+Clarity and conciseness is preferred over personality. Tone may reflect the individual writing but shouldn't interfere with the clarity of the message.
+
+If posting on social media on behalf of the DRF, extra consideration should be taken to ensure conciseness.
+
+We recommend against using AI for any copy unless you are familiar with using it as a part of the workflow and maintaining your own authentic voice.
+
+## Guidelines
+
+### Everywhere
+
+- Use second-person pronouns to address the reader directly.
+- Use the active voice over passive voice.
+- Use inclusive language that welcomes all community members.
+- Short sentences are preferred over complex ones.
+- Include practical examples and actionable insights where applicable.
+
+### Avoid
+
+- Technical jargon.
+- Marketing phrases.
+- Ableist language.
+- Sounding corporate.
+- Long paragraphs.
+- Statements about the future.
+- Assuming the reader has a specific level of understanding (words such as just, simply, easily etc).
+
+### Representing the DRF on the website and social media
+
+- Avoid humor or excessive colloquialisms.
+- Avoid excessive formality, e.g. "Please note that".
+- Avoid patronizing or dismissive phrasing.
+- Use active language, e.g. "To contact us, email us@email.org".
+- Avoid filler phrases.
+
+### Guidelines for representing yourself under the DRF
+
+- Humor has to translate well and shouldn't be at someone's expense — including DRF and LF sponsors.
+- Your expertise, and therefore your unique delivery of it, is valuable.
+- Short anecdotes are great if they are an example of your expertise and conducive to the narrative of a piece of work.
+- The excellence of your work should speak for itself.
+
+### SEO
+
+#### Organization naming
+
+- First mention: Developer Relations Foundation (DevRel Foundation, DRF). Only include 'DRF' if it required after the first mention.
+- Subequent mentions: DevRel Foundation
+- DRF: Only use after the first mention when space, repetition, or context calls for it (e.g. social, governance, longer-form content).
+
+Including the full name on first mention connects the formal name, common brand name, and acronym for readers and search engines. DRF is already in public use across the website, blog, GitHub, LinkedIn, and community channels — this standard reflects that practice.
+
+#### Content structure
+
+When drafting content for others to publish (e.g. blog posts), write in plain text and use heading levels:
+
+- `Title (H1):` the article title
+- `Section header (H2):` each major section
+- `Subsection (H3):` supporting points when needed
+
+The person publishing can then apply the correct heading levels on the site. This keeps content scannable, accessible, and easier for search engines to understand.

--- a/src/routes/brand/voice-and-tone.md.d.ts
+++ b/src/routes/brand/voice-and-tone.md.d.ts
@@ -1,0 +1,4 @@
+import type { Component } from 'svelte';
+
+declare const VoiceAndTone: Component;
+export default VoiceAndTone;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,25 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
-	}
+		"moduleResolution": "bundler",
+		"allowArbitraryExtensions": true
+	},
+	"include": [
+		".svelte-kit/ambient.d.ts",
+		".svelte-kit/non-ambient.d.ts",
+		".svelte-kit/types/**/$types.d.ts",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.d.ts",
+		"src/**/*.svelte",
+		"src/**/*.md",
+		"src/**/*.svx",
+		"tests/**/*.js",
+		"tests/**/*.ts",
+		"tests/**/*.svelte",
+		"vite.config.js",
+		"vite.config.ts"
+	]
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
- added voice and tone subsection to branding area
- moved terms of use to the footer; this shouldn't be in the brand guide
- edited contributing.md guide to avoid repetition of content